### PR TITLE
Rel. 11.0.9.1 - 2024-04-02 - Marginal optimizations for keybinding

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,7 +33,7 @@ jobs:
         with:
           allowUpdates: true
           name: Release ${{ steps.get-version.outputs.version }}
-          draft: false
+          draft: true
           prerelease: false
           token: ${{secrets.GITHUB_TOKEN}}
           artifacts: './module.zip, ./src/hot-pan/module.json, ./README.md, ./CHANGELOG.md'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,16 @@
 The **major** version number in my modules (like "11") always reflects the
 Foundry VTT **core** version it is compatible with (and recommended for).
 
-## 11.0.9.?
-### 2024-??-?? - Prepare next cycle
-- ???
+## 11.0.9.1
+### 2024-04-02 - Marginal optimizations for keybinding
+- Adds translations for keybinding menu entry
+- Replaces recommended shortcut CTRL + P by SHIFT + P, to avoid interference with browser print function
 
 
 ## 11.0.9
 ### 2024-04-01 - Keybinding support ([enhancement request #6](https://github.com/coffiarts/FoundryVTT-hot-pan/issues/6))
-- Adds an optional keybinding for toggling on/off.
-- "Optional" means: There's no preassigned key combination. Assign it to your liking in the game settings (or ignore it if you don't want to use it). My personal preference is **CTRL + P** ("P" standing for "Pan")
+- Adds an optional keybinding for toggling on/off gamemasters only).
+- "Optional" means: There's no preassigned key combination. Assign it to your liking in the game settings (or ignore it if you don't want to use it). My personal preference is **SHIFT + P** ("P" standing for "Pan").
 - Credits to github member [p4535992](https://github.com/p4535992) for suggesting this.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 The **major** version number in my modules (like "11") always reflects the
 Foundry VTT **core** version it is compatible with (and recommended for).
 
+## 11.0.9.?
+### 2024-??-?? - Prepare next cycle
+- ???
+
+
 ## 11.0.9
 ### 2024-04-01 - Keybinding support ([enhancement request #6](https://github.com/coffiarts/FoundryVTT-hot-pan/issues/6))
 - Adds an optional keybinding for toggling on/off.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This screenshot shows the default values.
 <img src="src/hot-pan/artwork/hot-pan-settings.png" alt="Hot Pan & Zoom! settings"/>
 
 ## Toggle by hotkey
-You can assign a custom hotkey in the game settings (by default it is empty to prevent unwanted key collisions):
+You (gamemasters only) can assign a custom hotkey in the game settings (by default it is empty to prevent unwanted key collisions). My personal preference is **SHIFT + P** ("P" standing for "Pan"):
 
 <img src="src/hot-pan/artwork/hot-pan-keybinding-step1.png" alt="Hot Pan & Zoom! assign keybinding - step 1"/>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![](https://img.shields.io/badge/Foundry-v11-informational)
 ![GitHub All Releases](https://img.shields.io/github/downloads/coffiarts/FoundryVTT-hot-pan/latest/total?label=Downloads+latest+release)
-![GitHub All Releases](https://img.shields.io/github/downloads/coffiarts/FoundryVTT-hot-pan/11.0.8/total?label=previous+release+[11.0.8])
+![GitHub All Releases](https://img.shields.io/github/downloads/coffiarts/FoundryVTT-hot-pan/11.0.9/total?label=previous+release+[11.0.9])
 
 # Hot Pan & Zoom! for Foundry VTT
 <table style="border:0">
@@ -33,6 +33,7 @@ This is absolutely optional! Don't feel obliged in any way to do so. My mod is a
 * [What does it do ...](#what-does-it-do-)
 * [Changelog](#changelog)
 * [Adjustable module settings](#adjustable-module-settings)
+* [Toggle by hotkey](#toggle-by-hotkey)
 * [Control it by macro](#control-it-by-macro)
 * [Compatibility and Dependencies](#compatibility-and-dependencies)
 * [Upcoming features](#upcoming-features)

--- a/src/hot-pan/lang/de.json
+++ b/src/hot-pan/lang/de.json
@@ -40,6 +40,7 @@
     "onOffUIMessage": {
       "whenON": "Bildschirm wird vom Spielleiter gesteuert!",
       "whenOFF": "Bildschirm ist wieder freigegeben."
-    }
+    },
+    "keybindingMenuLabel": "Hot Pan & Zoom! an-/ausschalten"
   }
 }

--- a/src/hot-pan/lang/en.json
+++ b/src/hot-pan/lang/en.json
@@ -40,6 +40,7 @@
     "onOffUIMessage": {
       "whenON": "Screen is remote controlled by the gamemaster!",
       "whenOFF": "Screen control has been released."
-    }
+    },
+    "keybindingMenuLabel": "Toggle Hot Pan & Zoom! on/off"
   }
 }

--- a/src/hot-pan/module.json
+++ b/src/hot-pan/module.json
@@ -3,7 +3,7 @@
   "name": "hot-pan",
   "title": "Hot Pan & Zoom!",
   "description": "&quot;One Thing to Pan Them! One Thing to Find Them! One Thing to Zoom them and to the GM's Canvas Bind Them!&quot;<br/>Hot Pan & Zoom! is a systems-agnostic utility for keeping players' canvas position & zoom in sync with the GM's screen. It runs in the backend, but is also controllable through macro code.",
-  "version": "11.0.9.?",
+  "version": "11.0.9.1",
   "url": "https://github.com/coffiarts/FoundryVTT-hot-pan",
   "manifest": "https://github.com/coffiarts/FoundryVTT-hot-pan/releases/download/latest/module.json",
   "download": "https://github.com/coffiarts/FoundryVTT-hot-pan/releases/download/latest/module.zip",

--- a/src/hot-pan/module.json
+++ b/src/hot-pan/module.json
@@ -3,7 +3,7 @@
   "name": "hot-pan",
   "title": "Hot Pan & Zoom!",
   "description": "&quot;One Thing to Pan Them! One Thing to Find Them! One Thing to Zoom them and to the GM's Canvas Bind Them!&quot;<br/>Hot Pan & Zoom! is a systems-agnostic utility for keeping players' canvas position & zoom in sync with the GM's screen. It runs in the backend, but is also controllable through macro code.",
-  "version": "11.0.9",
+  "version": "11.0.9.?",
   "url": "https://github.com/coffiarts/FoundryVTT-hot-pan",
   "manifest": "https://github.com/coffiarts/FoundryVTT-hot-pan/releases/download/latest/module.json",
   "download": "https://github.com/coffiarts/FoundryVTT-hot-pan/releases/download/latest/module.zip",

--- a/src/hot-pan/scripts/config.js
+++ b/src/hot-pan/scripts/config.js
@@ -50,9 +50,9 @@ export class Config {
 
         // Add the keybinding
         game.keybindings.register("hot-pan", "active", {
-            name: "Toggle Hot Pan & Zoom!",
+            name: Config.localize('keybindingMenuLabel'),
             editable: [
-                //{ key: "KeyP", modifiers: [KeyboardManager.MODIFIER_KEYS.CONTROL] }
+                //{ key: "KeyL", modifiers: [KeyboardManager.MODIFIER_KEYS.SHIFT] }
             ],
             restricted: true,
             onDown: () => {


### PR DESCRIPTION
## 11.0.9.1 - 2024-04-02 - Marginal optimizations for keybinding
- Adds translations for keybinding menu entry
- Replaces recommended shortcut CTRL + P by SHIFT + P, to avoid interference with browser print function

(!) Attention: Both "Source code" packages (zip and tar.gz) are outdated in this release due to some unclarified issue in the release build. Shouldn't do any harm though, as they're only informational and never being used by Foundry itself. Just be aware that those sources (if you should have a look into them) do NOT contain the latest changes. Use "[module.zip](https://github.com/coffiarts/FoundryVTT-hot-pan/releases/download/latest/module.zip)" as the source of truth.